### PR TITLE
Add better ngrok waiting and multiple agents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,7 @@
-version: '3'
+version: "3"
 services:
   ngrok:
-    container_name: ngrok
     image: wernight/ngrok
-    command: ngrok http agent:3000
-
+    command: ngrok http agent:3000 --log stdout
   agent:
     build: .
-    depends_on:
-      - ngrok 

--- a/docker-compose_multiple.yml
+++ b/docker-compose_multiple.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  ngrok-1:
+    image: wernight/ngrok
+    command: ngrok http agent-1:3000 --log stdout
+  agent-1:
+    build: .
+    environment:
+      NGROK_NAME: ngrok-1
+  ngrok-2:
+    image: wernight/ngrok
+    command: ngrok http agent-2:3000 --log stdout
+  agent-2:
+    build: .
+    environment:
+      NGROK_NAME: ngrok-2

--- a/medici-startup.sh
+++ b/medici-startup.sh
@@ -1,4 +1,23 @@
-ENDPOINT=$(curl --silent ngrok:4040/api/tunnels | ./jq -r '.tunnels[0].public_url')
+#!/bin/bash
+
+NGROK_NAME=${NGROK_NAME:-ngrok}
+
+echo "ngrok end point [$NGROK_NAME]"
+
+ENDPOINT=null
+while [ $ENDPOINT = "null" ]
+do
+    echo "Fetching end point from ngrok service"
+    ENDPOINT=$(curl --silent $NGROK_NAME:4040/api/tunnels | ./jq -r '.tunnels[0].public_url')
+
+    if [ $ENDPOINT = "null" ]; then
+        echo "ngrok not ready, sleeping 5 seconds...."
+        sleep 5
+    fi
+
+done
+
+echo "fetched end point [$ENDPOINT]"
 
 aca-py start \
     -it http 0.0.0.0 3000 \


### PR DESCRIPTION
To better assist in making sure the ngrok service is up and running, and
has a tunnel established. The `medici-startup.sh` has a wait loop that
will attempt to connect to ngrok and wait till it has a valid request
before proceeding

There is also a second docker-compose file that will fire up multiple
agents for testing propses.

The ngrok utility also has logging enabled to assist in making sure the
ngrok service is alive and healthy.